### PR TITLE
Fixed audio issue while recording longer videos

### DIFF
--- a/ios/Plugin/CameraController.swift
+++ b/ios/Plugin/CameraController.swift
@@ -432,7 +432,8 @@ extension CameraController {
             }
         }
         
-        videoOutput!.startRecording(to: fileUrl, recordingDelegate: self)
+        videoOutput?.movieFragmentInterval = CMTime.invalid
+        videoOutput?.startRecording(to: fileUrl, recordingDelegate: self)
         completion(nil)
     }
 


### PR DESCRIPTION
The mp4 format recorded in fragments of 10 seconds, so I disabled this option because there was no audio if the recording was longer than 10 seconds